### PR TITLE
Add empty commit to addDevTag script

### DIFF
--- a/utils/addDevTag
+++ b/utils/addDevTag
@@ -65,6 +65,9 @@ then
     exit 1
 fi
 
+# add empty commit to rebuild all jars'
+
+git commit -am 'rebuild all jars'
 
 # tag this commit and push it------------
 


### PR DESCRIPTION
Adding empty commit to addDevTag script.
This is done at the end of the script, after checking that everything is fine, and before actually adding the tag.