### PR TITLE
fix: make addReleaseTag tag-only, stop duplicate jar commits

### DIFF
--- a/utils/addReleaseTag
+++ b/utils/addReleaseTag
@@ -114,22 +114,11 @@ then
   fi
 fi
 
-# Build and commit JARs to ensure the repo has the release build
-./runBuild
-if [[ $? -ne 0 ]]
-then
-    echo "Failed to build"
-    exit 1
-fi
-
-# We have to do git add twice like this otherwise jar changes in ./jar/* do not get added
-git add --all "./jar/*" > /dev/null 2>&1
-git add --all "./**/jar/*" > /dev/null 2>&1
-
-if ! git diff --cached --quiet 2>/dev/null; then
-    git commit -m "build for release v$version"
-    git push
-fi
+# NOTE: this script no longer builds or commits JARs. That is owned by
+# generate-jars.yml (the build-jars job) in supertokens-core, which rebuilds,
+# commits and re-tags after this script has created the release tag. Building
+# here as well produced a duplicate "build for release" commit on every
+# release, since JAR rebuilds are never byte-identical.
 
 releasePassword=`cat ../releasePassword`
 


### PR DESCRIPTION
## Summary

Every Java 21 release currently leaves **two identical-looking bot commits** on the release branch (e.g. [`v11.3.5...v11.3.6`](https://github.com/supertokens/supertokens-core/compare/v11.3.5...v11.3.6)):

```
d5a7933a  build for release v11.3.6   (21:38)
af37bc5a  build for release v11.3.6   (21:42)
```

Cause: two systems both build and commit the release JARs.

1. `utils/addReleaseTag` (this repo, injected into each module repo by `loadModules`) runs `./runBuild`, commits `build for release vX.Y.Z`, and tags — during the `add-release-tags` job.
2. `generate-jars.yml` in supertokens-core (the `build-jars` job that runs right after) checks out the tag, rebuilds, commits with the same message, and force-moves the tag.

The second commit is never a no-op because JAR rebuilds are not byte-reproducible (zip entries embed build timestamps), so the `git diff --cached --quiet` guard never triggers.

## Change

Remove the build+commit block from `utils/addReleaseTag`, making it tag-only — matching the `for_jdk_15_releases` version of the script. JAR building is owned by `generate-jars.yml`, which also uploads the JARs to S3 and builds the downloadable install packages.

## Notes

- Canary releases are unaffected (they skip the `Tag core` step entirely).
- Java 15 releases are unaffected (they use the `for_jdk_15_releases` branch of this repo, whose script never built JARs).
- Trade-off: if `build-jars` fails, the release tag temporarily has no committed JARs (previously the `addReleaseTag` build provided them). Recovery is the existing "Retroactively Generate JARs" dispatch in supertokens-core, and S3 — not the in-repo jars — is the distribution source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)